### PR TITLE
Fixed issue with autolayer container

### DIFF
--- a/addons/mixing-desk/music/containers/autofade_cont.gd
+++ b/addons/mixing-desk/music/containers/autofade_cont.gd
@@ -12,12 +12,14 @@ export(bool) var invert
 export(float, 0.0, 1.0) var track_speed
 
 var param
+var target
 
 func _ready():
 	get_node("../..").connect("beat", self, "_update")
+	target = get_node(target_node)
 
 func _update(beat):
-	param = get_node(target_node).get(target_property)
+	param = target.get(target_property)
 	if !toggle:
 		var vol : float
 		if !invert:
@@ -39,16 +41,11 @@ func _update(beat):
 			for i in get_children():
 				_fade_to(i, -60)
 
-func _check_equal(a : float,b : float):
-	var aa = floor(a)
-	var bb = floor(b)
-	return (aa == bb)
-
 func _fade_to(target, vol):
 	var is_match
 	var cvol = target.volume_db
 	var sum = vol - cvol
-	is_match = _check_equal(cvol,vol)
+	is_match = abs(cvol-vol) < .01
 	if !is_match:
 		cvol = lerp(cvol,vol,track_speed)
 		target.volume_db = cvol

--- a/addons/mixing-desk/music/containers/autolayer_cont.gd
+++ b/addons/mixing-desk/music/containers/autolayer_cont.gd
@@ -14,15 +14,18 @@ export(int) var pad = 0
 export(bool) var invert
 export(float) var track_speed
 
+var target
+
 var cont = "autolayer"
 
 func _ready():
 	get_node("../..").connect("beat", self, "_update")
+	target = get_node(target_node)
 
 func _update(beat):
 	var layer = layer_max
 	if automate:
-		num = get_node(target_node).get(target_property)
+		num = target.get(target_property)
 		if !invert:
 			num -= min_range
 			num /= (max_range - min_range)
@@ -37,9 +40,8 @@ func _update(beat):
 			layer_min = -1
 			layer_max = layer
 		1:
-			if layer != 0:
-				layer_max = layer
-				layer_min = layer - 1
+			layer_max = layer
+			layer_min = layer - 1
 		2:
 			if pad != 0:
 				layer_min = layer - pad
@@ -47,26 +49,19 @@ func _update(beat):
 	_fade_layers()
 
 func _fade_layers():
-	for i in get_children():
-		var child = (i.get_index())
-		if child != -1:
-			if child <= layer_min:
-				_fade_to(i,-60)
-			if (child > layer_min) and (child <= layer_max):
-				_fade_to(i,0)
-			if child > layer_max:
-				_fade_to(i,-60)
-
-func _check_equal(a : float,b : float):
-	var aa = floor(a)
-	var bb = floor(b)
-	return (aa == bb)
+	for i in range(get_child_count()):
+		var child = get_child(i)
+		if i != -1:
+			if i < layer_min or i > layer_max:
+				_fade_to(child,-60)
+			else:
+				_fade_to(child,0)
 
 func _fade_to(target, vol):
 	var is_match
 	var cvol = target.volume_db
 	var sum = vol - cvol
-	is_match = _check_equal(cvol,vol)
+	is_match = abs(cvol-vol) < .01
 	if !is_match:
 		cvol = lerp(cvol,vol,track_speed)
 		target.volume_db = cvol


### PR DESCRIPTION
Previously, AutoLayerContainer would have issues when there were 2 child audio players, which should now be resolved. Additionally, the method _check_equal has been replaced with an absolute value comparison in both AutoLayerContainer and AutoFadeContainer. Those two classes have also had their targets set on _ready so get_node doesn't need to be called each update