### PR TITLE
Improvements on fading containers (AutoLayer & AutoFade)

### DIFF
--- a/addons/mixing-desk/music/containers/autofade_cont.gd
+++ b/addons/mixing-desk/music/containers/autofade_cont.gd
@@ -6,8 +6,8 @@ export(play_type) var play_style
 export var toggle : bool = false
 export(NodePath) var target_node
 export(String) var target_property
-export(float) var min_range
-export(float) var max_range
+export(float) var min_range = 0.0
+export(float) var max_range = 1.0
 export(bool) var invert
 export(float, 0.0, 1.0) var track_speed
 
@@ -46,14 +46,13 @@ func init_volume():
 				i.volume_db = -65
 
 func _get_range_vol() -> float:
-	var vol: float
+	var vol: float = param
 	if !invert:
 		vol -= min_range
-		vol /= (max_range - min_range)
 	else:
-		vol = param * -1
+		vol *= -1
 		vol += max_range
-		vol /= (max_range - min_range)
+	vol /= abs(max_range - min_range)
 	vol = (vol*65) - 65
 	vol = clamp(vol,-65,0)
 

--- a/addons/mixing-desk/music/containers/autofade_cont.gd
+++ b/addons/mixing-desk/music/containers/autofade_cont.gd
@@ -17,29 +17,47 @@ var target
 func _ready():
 	get_node("../..").connect("beat", self, "_update")
 	target = get_node(target_node)
+	init_volume()
 
 func _update(beat):
 	param = target.get(target_property)
 	if !toggle:
-		var vol : float
-		if !invert:
-			vol -= min_range
-			vol /= (max_range - min_range)
-		else:
-			vol = param * -1
-			vol += max_range
-			vol /= (max_range - min_range)
-		vol = (vol*65) - 65
-		vol = clamp(vol,-65,0)
+		var vol := _get_range_vol()
 		for i in get_children():
 			_fade_to(i, vol)
 	else:
-		if param:
-			for i in get_children():
+		for i in get_children():
+			if param:
 				_fade_to(i, 0)
-		else:
-			for i in get_children():
+			else:
 				_fade_to(i, -65)
+				
+func init_volume():
+	param = target.get(target_property)
+	if !toggle:
+		var vol := _get_range_vol()
+		for i in get_children():
+			i.volume_db = vol
+	else:
+		for i in get_children():
+			if param:
+				i.volume_db = 0
+			else:
+				i.volume_db = -65
+
+func _get_range_vol() -> float:
+	var vol: float
+	if !invert:
+		vol -= min_range
+		vol /= (max_range - min_range)
+	else:
+		vol = param * -1
+		vol += max_range
+		vol /= (max_range - min_range)
+	vol = (vol*65) - 65
+	vol = clamp(vol,-65,0)
+
+	return vol
 
 func is_equal(a : float,b : float):
 	return int(a) == int(b)

--- a/addons/mixing-desk/music/containers/autofade_cont.gd
+++ b/addons/mixing-desk/music/containers/autofade_cont.gd
@@ -50,7 +50,10 @@ func _fade_to(target, vol):
 	is_match = is_equal(cvol,vol)
 	if !is_match:
 		if cvol > vol:
-			cvol -= 1
+			if track_speed < 1.0:
+				cvol -= 1.5 / (1.0 - track_speed )
+			else:
+				cvol = vol
 		else:
 			cvol = lerp(cvol,vol,track_speed)
 		target.volume_db = cvol

--- a/addons/mixing-desk/music/containers/autolayer_cont.gd
+++ b/addons/mixing-desk/music/containers/autolayer_cont.gd
@@ -7,8 +7,8 @@ export(int) var layer_max
 export(bool) var automate = false
 export(NodePath) var target_node
 export(String) var target_property
-export(float) var min_range
-export(float) var max_range
+export(float) var min_range = 0.0
+export(float) var max_range = 1.0
 export(int) var pad = 0
 export(bool) var invert
 export(float) var track_speed
@@ -43,11 +43,10 @@ func _set_layers_values():
 		num = target.get(target_property)
 		if !invert:
 			num -= min_range
-			num /= (max_range - min_range)
 		else:
 			num *= -1
 			num += max_range
-			num /= (max_range - min_range)
+		num /= abs(max_range - min_range)
 		num *= (get_child_count())
 		t_layer = clamp(floor(num), -1, get_child_count() - 1)
 	match play_style:

--- a/addons/mixing-desk/music/containers/autolayer_cont.gd
+++ b/addons/mixing-desk/music/containers/autolayer_cont.gd
@@ -67,7 +67,10 @@ func _fade_to(target, vol):
 	is_match = is_equal(vol,cvol)
 	if !is_match:
 		if cvol > vol:
-			cvol -= 1
+			if track_speed < 1.0:
+				cvol -= 1.5 / (1.0 - track_speed )
+			else:
+				cvol = vol
 		else:
 			cvol = lerp(cvol,vol,track_speed)
 		target.volume_db = cvol

--- a/addons/mixing-desk/music/containers/autolayer_cont.gd
+++ b/addons/mixing-desk/music/containers/autolayer_cont.gd
@@ -21,8 +21,23 @@ var cont = "autolayer"
 func _ready():
 	get_node("../..").connect("beat", self, "_update")
 	target = get_node(target_node)
-
+	init_layers()
+	
 func _update(beat):
+	_set_layers_values()
+	_fade_layers()
+	
+func init_layers():
+	_set_layers_values()
+	for i in range(get_child_count()):
+		var child = get_child(i)
+		if i != -1:
+			if i < layer_min or i > layer_max:
+				child.volume_db = -65
+			else:
+				child.volume_db = 0
+	
+func _set_layers_values():
 	t_layer = layer_max
 	if automate:
 		num = target.get(target_property)
@@ -36,17 +51,16 @@ func _update(beat):
 		num *= (get_child_count())
 		t_layer = clamp(floor(num), -1, get_child_count() - 1)
 	match play_style:
-		0:
+		play_mode.additive:
 			layer_min = -1
 			layer_max = t_layer
-		1:
+		play_mode.single:
 			layer_min = t_layer
 			layer_max = t_layer
-		2:
+		play_mode.pad:
 			if pad != 0:
 				layer_min = t_layer - pad
 				layer_max = t_layer + pad
-	_fade_layers()
 
 func _fade_layers():
 	for i in range(get_child_count()):


### PR DESCRIPTION
Hello. I've recently used this plugin on a project, and came across some limitations of the AutoLayer container. Thus I edited it a bit to obtain what I needed. I think those changes could benefit other users:

- Fade-out takes `track_speed` into account to be (approximately) the same length as the fade- in
- Both AutoLayer and AutoFade initialize the AudioStreamPlayers volumes on `_ready`, so that there isn't an immediate fade-out when the song starts
- Fixed the volume calculation according to ranges in AutoFade, and set default values for ranges

Some remarks:

- The fade-out I implemented doesn't follow exactly the same curve as the fade-in. It would require a reversed logarithm, which is quite tricky to compute giving how the volume is updated at each beat. Instead I opted for a linear function that feels close to the fade-in. When the fade-in is slow, so is the fade-out, etc… It's not perfect, but at least it prevents having always a constant slow fade out.
- Using tween for fading would be much more efficient than updating the volume on the beat, and would ensure a symmetry. However that would take a bit more time to implement. This PR is mostly a quick fix.
- I marked the functions `init_layers` and `init_volume` as public by choice. It seems reasonable that a dev would need to "reset" the layers at some point (if layers are dynamically calculated before the start of the song, or if the song is stopped and played later, etc…). Another solution would be for the MixingDesk to call these functions when it starts a song, maybe by emitting a signal.
- I had a lot of trouble figuring out what `Min Range` and `Max Range` were for and how to use them (for both auto containers), even after reading the code! Now that I see what they do, I'm not sure a lot of people will want to use them. Sure it's a neat system, but it's way too specific and confusing. Most users will just want to fade in and out some layers, and add their own logic on top. On _AutoFade_ especially, I think `toggle` should be the default mode. However that being said…
- **AutoFadeContainer** does basically the same thing as **AutoLayerContainer**, except that it's harder to use and can only have one layer. I suggest to remove it, as it brings too much confusion and redundancy. Most users will want to use the AutoLayer to do vertical layering with fading, by just selecting the layers they want and the length of the fading.

That being say thank you for this plugin! Dynamic music is tricky to implement, and I'm glad that there is now a tool for that in Godot.